### PR TITLE
add missing libraries

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,10 @@
 from setuptools import find_packages
 from setuptools import setup
 
-REQUIRED_PACKAGES = ['pytest','aocr', 'numpy', 'opencv-python', 'Flask', 'flask_restful', 'flask_httpauth', 'pytest-shutil', 'pillow', 'pyppeteer']
+REQUIRED_PACKAGES = [
+    'pytest', 'aocr', 'numpy', 'opencv-python', 'Flask', 'flask_restful',
+    'flask_httpauth', 'pytest-shutil', 'pillow', 'pyppeteer', 'requests'
+]
 VERSION = 'v1.0.5'
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,8 @@ from setuptools import setup
 
 REQUIRED_PACKAGES = [
     'pytest', 'aocr', 'numpy', 'opencv-python', 'Flask', 'flask_restful',
-    'flask_httpauth', 'pytest-shutil', 'pillow', 'pyppeteer', 'requests'
+    'flask_httpauth', 'flask-cors', 'pytest-shutil', 'pillow', 'pyppeteer',
+    'requests'
 ]
 VERSION = 'v1.0.5'
 


### PR DESCRIPTION
after installing captcha22 and running `captcha22 client label --image-type=png --input=captchas`:

```
Traceback (most recent call last):
  File "/Users/thijs/.virtualenvs/captcha/bin/captcha22", line 5, in <module>
    from captcha22.__main__ import main
  File "/Users/thijs/.virtualenvs/captcha/lib/python3.7/site-packages/captcha22/__init__.py", line 3, in <module>
    from captcha22.lib.api.server import ApiServer
  File "/Users/thijs/.virtualenvs/captcha/lib/python3.7/site-packages/captcha22/lib/api/server.py", line 13, in <module>
    import requests
ModuleNotFoundError: No module named 'requests'
```